### PR TITLE
feat: ajouter un bouton pour copier la transcription

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -95,6 +95,35 @@ audio {
   background-color: #2c2c2c;
   min-height: 100px;
   text-align: left;
+  width: 100%;
+}
+
+.transcription-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.copy-btn {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.copy-btn:hover {
+  background-color: #0056b3;
+}
+
+.transcription-text {
+  background-color: #f9f9f9;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 .loading, .error {
@@ -104,9 +133,4 @@ audio {
 
 .error {
   color: #ff6b6b;
-}
-
-.transcription-text {
-  white-space: pre-wrap;
-  word-wrap: break-word;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ function App() {
   const [transcription, setTranscription] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [copySuccess, setCopySuccess] = useState(false);
 
   const handleStop = async (_blobUrl: string, blob: Blob) => {
     setIsLoading(true);
@@ -40,6 +41,18 @@ function App() {
     }
   };
 
+  const copyToClipboard = () => {
+    if (transcription) {
+      navigator.clipboard.writeText(transcription).then(() => {
+        setCopySuccess(true);
+        setTimeout(() => setCopySuccess(false), 2000); // Réinitialise après 2 secondes
+      }, () => {
+        // Gérer l'échec de la copie si nécessaire
+        console.error("Échec de la copie dans le presse-papiers");
+      });
+    }
+  };
+
   return (
     <div className="container">
       <h1>Audio Scribe</h1>
@@ -65,7 +78,14 @@ function App() {
       />
 
       <div className="transcription-container">
-        <h2>Transcription</h2>
+        <div className="transcription-header">
+          <h2>Transcription</h2>
+          {transcription && (
+            <button onClick={copyToClipboard} className="copy-btn">
+              {copySuccess ? "Copié !" : "Copier"}
+            </button>
+          )}
+        </div>
         {isLoading && <p className="loading">Transcription en cours...</p>}
         {error && <p className="error">Erreur: {error}</p>}
         {transcription && <p className="transcription-text">{transcription}</p>}

--- a/gitignore
+++ b/gitignore
@@ -16,3 +16,6 @@ frontend/dist/
 .DS_Store
 .vscode/
 .idea/ 
+
+# Cursor
+.cursor/ 


### PR DESCRIPTION
Ajoute un bouton 'Copier' à l'interface utilisateur pour permettre aux utilisateurs de copier facilement le texte de la transcription dans leur presse-papiers. La fonctionnalité inclut un retour visuel, le bouton affichant 'Copié !' après le clic.